### PR TITLE
Refinements

### DIFF
--- a/src/ConsoleApp/Models/Model1.cs
+++ b/src/ConsoleApp/Models/Model1.cs
@@ -1,0 +1,25 @@
+namespace ConsoleApp.Models
+{
+    public class Model1
+    {
+        /// <summary>
+        /// The first name
+        /// </summary>
+        public string FirstName { get; set; } = default!;
+
+        /// <summary>
+        /// The last name
+        /// </summary>
+        public string LastName { get; set; } = default!;
+
+        /// <summary>
+        /// The email
+        /// </summary>
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// The age
+        /// </summary>
+        public int Age { get; set; }
+    }
+}

--- a/src/ConsoleApp/Models/Model2.cs
+++ b/src/ConsoleApp/Models/Model2.cs
@@ -1,0 +1,15 @@
+namespace ConsoleApp.Models
+{
+    public class Model2
+    {
+        /// <summary>
+        /// The users Bio
+        /// </summary>
+        public string Bio { get; set; } = default!;
+
+        /// <summary>
+        /// The users Bio
+        /// </summary>
+        public string Website { get; set; } = default!;
+    }
+}

--- a/src/ConsoleApp/Models/Model3.cs
+++ b/src/ConsoleApp/Models/Model3.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace ConsoleApp.Models
+{
+    public class Model3
+    {
+        /// <summary>
+        /// Family members
+        /// </summary>
+        public List<string>? FamilyMembers { get; set; }
+    }
+}

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -1,56 +1,24 @@
 ﻿using System;
+using System.Text.Json;
+using ConsoleApp.Models;
 using SG1.UtilityTypes;
 
 namespace ConsoleApp
 {
-    public class Model1
-    {
-        /// <summary>
-        /// The first name
-        /// </summary>
-        public string FirstName { get; set; } = default!;
-
-        /// <summary>
-        /// The last name
-        /// </summary>
-        public string LastName { get; set; } = default!;
-
-        /// <summary>
-        /// The email
-        /// </summary>
-        public string? Email { get; set; }
-
-        /// <summary>
-        /// The age
-        /// </summary>
-        public int Age { get; set; }
-    }
-
-    public class Model2
-    {
-        /// <summary>
-        /// The users Bio
-        /// </summary>
-        public string Bio { get; set; } = default!;
-
-        /// <summary>
-        /// The users Bio
-        /// </summary>
-        public string Website { get; set; } = default!;
-    }
 
     [Partial(typeof(Model1))]
     public partial class Model1Partial { }
 
-    [Pick(typeof(Model1), new string[] { "FirstName" })]
+    [Pick(typeof(Model1), "FirstName")]
     public partial class Model1Picked { }
 
-    [Omit(typeof(Model1), new string[] { "FirstName" })]
+    [Omit(typeof(Model1), "FirstName")]
     public partial class Model1Omit { }
 
     [
         Readonly(typeof(Model1)),
-        Pick(typeof(Model1), new string[] { "FirstName" })
+        Pick(typeof(Model1), "FirstName")
+    // TODO: Fix this combo
     ]
     public partial class Model1Readonly
     {
@@ -61,6 +29,7 @@ namespace ConsoleApp
             FirstName = firstName;
         }
     }
+
     [
         Partial(typeof(Model1)),
         Partial(typeof(Model2)),
@@ -69,41 +38,40 @@ namespace ConsoleApp
     {
     }
 
+    [
+        Partial(typeof(Model1)),
+        Partial(typeof(Model2)),
+        Partial(typeof(Model3)),
+    ]
+    public partial class Model1And2And3
+    {
+    }
+
     class Program
     {
         static void Main(string[] args)
         {
-            var partial = new Model1Partial
+            WriteType(typeof(Model1Partial));
+            WriteType(typeof(Model1Picked));
+            WriteType(typeof(Model1Readonly));
+            WriteType(typeof(Model1And2));
+            WriteType(typeof(Model1Omit));
+            WriteType(typeof(Model1And2And3));
+
+            var parsed = JsonSerializer.Deserialize<Model1And2And3>("{}");
+            Console.WriteLine(JsonSerializer.Serialize(parsed, new JsonSerializerOptions
             {
-                FirstName = null,
-                LastName = "tester",
-                Email = "testere",
-            };
-            var picked = new Model1Picked
+                WriteIndented = true
+            }));
+        }
+
+        static void WriteType(Type type)
+        {
+            Console.WriteLine($"Properties on {type.Name}:");
+            foreach (var property in type.GetProperties())
             {
-                FirstName = "test"
-            };
-            var ro = new Model1Readonly("test");
-            var model1And2 = new Model1And2
-            {
-                FirstName = "test",
-                LastName = "tester",
-                Email = "testere",
-                Age = 10,
-                Bio = "All about me",
-                Website = "https://google.com/me"
-            };
-            var omitted = new Model1Omit
-            {
-                LastName = "tester",
-                Email = "testere",
-                Age = 10
-            };
-            Console.WriteLine(
-                partial.FirstName +
-                partial.LastName +
-                partial.Email
-            );
+                Console.WriteLine($"\t{property.Name} of type {property.PropertyType.Name}");
+            }
         }
     }
 }

--- a/src/SG1.UtilityTypes.Tests/OmitAttributeTests.cs
+++ b/src/SG1.UtilityTypes.Tests/OmitAttributeTests.cs
@@ -5,13 +5,8 @@ namespace SG1.UtilityTypes.Tests
     public class OmitAttributeTests
     {
 
-        [SetUp]
-        public void Setup()
-        {
-        }
-
         [Test]
-        public void OmitAttributeTest()
+        public void Test1()
         {
             string source = @"
 namespace SG1.UtilityTypes.Tests.SampleClasses
@@ -29,6 +24,67 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
         public string LastName { get; set; } = default!;
         public string? Email { get; set; }
         public int Age { get; set; } = default!;
+    };
+}
+";
+            string output = TestUtilities.GetGeneratedOutput(source);
+
+            Assert.NotNull(output);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            string source = @"
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    [SG1.UtilityTypes.Omit(typeof(Model1), ""FirstName"")]
+    public partial class Model1Partial { }
+}";
+
+            string expectedOutput = @"using System;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public partial class Model1Partial
+    {
+        public string LastName { get; set; } = default!;
+        public string? Email { get; set; }
+        public int Age { get; set; } = default!;
+    };
+}
+";
+            string output = TestUtilities.GetGeneratedOutput(source);
+
+            Assert.NotNull(output);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        [Test]
+        public void Test3()
+        {
+            string source = @"
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    [
+        SG1.UtilityTypes.Partial(typeof(Model1)),
+        SG1.UtilityTypes.Omit(typeof(Model1), ""FirstName"")
+    ]
+    public partial class Model1Partial { }
+}";
+
+            string expectedOutput = @"using System;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public partial class Model1Partial
+    {
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public Nullable<int> Age { get; set; }
     };
 }
 ";

--- a/src/SG1.UtilityTypes.Tests/OmitAttributeTests.cs
+++ b/src/SG1.UtilityTypes.Tests/OmitAttributeTests.cs
@@ -84,7 +84,7 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
     {
         public string? LastName { get; set; }
         public string? Email { get; set; }
-        public Nullable<int> Age { get; set; }
+        public int? Age { get; set; }
     };
 }
 ";

--- a/src/SG1.UtilityTypes.Tests/PartialAttributeTests.cs
+++ b/src/SG1.UtilityTypes.Tests/PartialAttributeTests.cs
@@ -24,7 +24,7 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
         public string? FirstName { get; set; }
         public string? LastName { get; set; }
         public string? Email { get; set; }
-        public Nullable<int> Age { get; set; }
+        public int? Age { get; set; }
     };
 }
 ";
@@ -42,7 +42,7 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
 
 namespace SampleNamespace
 {
-    [Partial(typeof(SG1.UtilityTypes.Tests.SampleClasses.Model1), ""Optional"", true)]
+    [Partial(typeof(SG1.UtilityTypes.Tests.SampleClasses.Model1), typeof(Microsoft.CodeAnalysis.Optional<object>), true)]
     public partial class Model1Partial { }
 }";
             string expectedOutput = @"using System;
@@ -51,10 +51,10 @@ namespace SampleNamespace
 {
     public partial class Model1Partial
     {
-        public Optional<string> FirstName { get; set; }
-        public Optional<string> LastName { get; set; }
-        public Optional<string?> Email { get; set; }
-        public Optional<int> Age { get; set; }
+        public Microsoft.CodeAnalysis.Optional<string> FirstName { get; set; }
+        public Microsoft.CodeAnalysis.Optional<string> LastName { get; set; }
+        public Microsoft.CodeAnalysis.Optional<string?> Email { get; set; }
+        public Microsoft.CodeAnalysis.Optional<int> Age { get; set; }
     };
 }
 ";

--- a/src/SG1.UtilityTypes.Tests/PickAttributeTests.cs
+++ b/src/SG1.UtilityTypes.Tests/PickAttributeTests.cs
@@ -6,7 +6,7 @@ namespace SG1.UtilityTypes.Tests
     {
 
         [Test]
-        public void PickAttributeTest()
+        public void Test1()
         {
             string source = @"
 namespace SG1.UtilityTypes.Tests.SampleClasses
@@ -22,6 +22,63 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
     public partial class Model1Partial
     {
         public string FirstName { get; set; } = default!;
+    };
+}
+";
+            string output = TestUtilities.GetGeneratedOutput(source);
+
+            Assert.NotNull(output);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            string source = @"
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    [SG1.UtilityTypes.Pick(typeof(Model3), new string[] { ""FamilyMembers"" })]
+    public partial class Model3Picked { }
+}";
+
+            string expectedOutput = @"using System;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public partial class Model3Picked
+    {
+        public System.Collections.Generic.List<string>? FamilyMembers { get; set; }
+    };
+}
+";
+            string output = TestUtilities.GetGeneratedOutput(source);
+
+            Assert.NotNull(output);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        [Test]
+        public void Test3()
+        {
+            string source = @"
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    [
+        SG1.UtilityTypes.Readonly(typeof(Model1)),
+        SG1.UtilityTypes.Pick(typeof(Model1), ""FirstName"")
+    ]
+    public partial class Model1Picked { }
+}";
+
+            string expectedOutput = @"using System;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public partial class Model1Picked
+    {
+        public string FirstName { get; } = default!;
     };
 }
 ";

--- a/src/SG1.UtilityTypes.Tests/ReadonlyAttributeTests.cs
+++ b/src/SG1.UtilityTypes.Tests/ReadonlyAttributeTests.cs
@@ -35,5 +35,69 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
             Assert.AreEqual(expectedOutput, output);
         }
 
+        [Test]
+        public void Test2()
+        {
+            string source = @"
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    [
+        SG1.UtilityTypes.Partial(typeof(Model1)),
+        SG1.UtilityTypes.Readonly(typeof(Model1))
+    ]
+    public partial class Model1Partial { }
+}";
+
+            string expectedOutput = @"using System;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public partial class Model1Partial
+    {
+        public string? FirstName { get; }
+        public string? LastName { get; }
+        public string? Email { get; }
+        public Nullable<int> Age { get; }
+    };
+}
+";
+            string output = TestUtilities.GetGeneratedOutput(source);
+
+            Assert.NotNull(output);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+
+        [Test]
+        public void Test3()
+        {
+            string source = @"
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    [
+        SG1.UtilityTypes.Partial(typeof(Model1)),
+        SG1.UtilityTypes.Readonly(typeof(Model1)),
+        SG1.UtilityTypes.Pick(typeof(Model1), ""FirstName"")
+    ]
+    public partial class Model1Partial { }
+}";
+
+            string expectedOutput = @"using System;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public partial class Model1Partial
+    {
+        public string? FirstName { get; }
+    };
+}
+";
+            string output = TestUtilities.GetGeneratedOutput(source);
+
+            Assert.NotNull(output);
+
+            Assert.AreEqual(expectedOutput, output);
+        }
     }
 }

--- a/src/SG1.UtilityTypes.Tests/ReadonlyAttributeTests.cs
+++ b/src/SG1.UtilityTypes.Tests/ReadonlyAttributeTests.cs
@@ -57,7 +57,7 @@ namespace SG1.UtilityTypes.Tests.SampleClasses
         public string? FirstName { get; }
         public string? LastName { get; }
         public string? Email { get; }
-        public Nullable<int> Age { get; }
+        public int? Age { get; }
     };
 }
 ";

--- a/src/SG1.UtilityTypes.Tests/SampleClasses/Model2.cs
+++ b/src/SG1.UtilityTypes.Tests/SampleClasses/Model2.cs
@@ -1,0 +1,15 @@
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public class Model2
+    {
+        /// <summary>
+        /// The users Bio
+        /// </summary>
+        public string Bio { get; set; } = default!;
+
+        /// <summary>
+        /// The users Bio
+        /// </summary>
+        public string Website { get; set; } = default!;
+    }
+}

--- a/src/SG1.UtilityTypes.Tests/SampleClasses/Model3.cs
+++ b/src/SG1.UtilityTypes.Tests/SampleClasses/Model3.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace SG1.UtilityTypes.Tests.SampleClasses
+{
+    public class Model3
+    {
+        /// <summary>
+        /// Family members
+        /// </summary>
+        public List<string>? FamilyMembers { get; set; }
+    }
+}

--- a/src/SG1.UtilityTypes/ClassBuilder.cs
+++ b/src/SG1.UtilityTypes/ClassBuilder.cs
@@ -87,14 +87,14 @@ namespace SG1.UtilityTypes
                 var properties = transformationsGroup.Key.GetMembers().OfType<IPropertySymbol>().ToArray();
                 foreach (var property in properties)
                 {
-                    var shouldInclude = transformations.Select(t => t.ShouldIncludeProperty(property)).LastOrDefault();
+                    var shouldInclude = transformations.Select(t => t.ShouldIncludeProperty(property)).Where(t => t.HasValue).LastOrDefault();
                     if (shouldInclude.HasValue && !shouldInclude.Value)
                     {
                         continue;
                     }
 
-                    var propertyType = transformations.Select(t => t.GetPropertyType(property)).LastOrDefault() ?? property.Type.ToString();
-                    var shouldIncludePropertySetter = transformations.Select(t => t.ShouldIncludePropertySetter(property)).LastOrDefault();
+                    var propertyType = transformations.Select(t => t.GetPropertyType(property)).Where(t => !string.IsNullOrWhiteSpace(t)).LastOrDefault() ?? property.Type.ToString();
+                    var shouldIncludePropertySetter = transformations.Select(t => t.ShouldIncludePropertySetter(property)).Where(t => t.HasValue).LastOrDefault();
                     indentWriter.WriteLine(
                         PrintProperty(
                             property,

--- a/src/SG1.UtilityTypes/ClassBuilder.cs
+++ b/src/SG1.UtilityTypes/ClassBuilder.cs
@@ -32,6 +32,9 @@ namespace SG1.UtilityTypes
 
         private static string PrintProperty(IPropertySymbol property, ITypeSymbol propertyType, bool shouldIncludeSetter)
         {
+            // assign a default value when the property did not have a nullable annotation and the type has not been changed
+            var needsDefaultValue = property.NullableAnnotation != NullableAnnotation.Annotated && propertyType == property.Type;
+
             return String.Join(" ", new[] {
                 // needs more work to get comment
                 property.GetDocumentationCommentXml(CultureInfo.InvariantCulture),
@@ -42,8 +45,7 @@ namespace SG1.UtilityTypes
                 property.GetMethod != null ? "get;" : "",
                 property.SetMethod != null && shouldIncludeSetter ? "set;" : "",
                 "}",
-                property.NullableAnnotation != NullableAnnotation.Annotated  &&
-                    propertyType.ToString() == property.Type.ToString() ? "= default!;" : "",
+                needsDefaultValue ? "= default!;" : "",
             }.Where(i => i.Any()));
         }
 

--- a/src/SG1.UtilityTypes/ClassBuilder.cs
+++ b/src/SG1.UtilityTypes/ClassBuilder.cs
@@ -30,19 +30,20 @@ namespace SG1.UtilityTypes
             return "";
         }
 
-        private static string PrintProperty(IPropertySymbol property, string propertyType, bool shouldIncludeSetter)
+        private static string PrintProperty(IPropertySymbol property, ITypeSymbol propertyType, bool shouldIncludeSetter)
         {
             return String.Join(" ", new[] {
                 // needs more work to get comment
                 property.GetDocumentationCommentXml(CultureInfo.InvariantCulture),
                 GetAccessibilityString(property.DeclaredAccessibility),
-                propertyType,
+                propertyType.ToString(),
                 property.Name,
                 "{",
                 property.GetMethod != null ? "get;" : "",
                 property.SetMethod != null && shouldIncludeSetter ? "set;" : "",
                 "}",
-                property.NullableAnnotation != NullableAnnotation.Annotated  && !(propertyType != property.Type.ToString()) ? "= default!;" : "",
+                property.NullableAnnotation != NullableAnnotation.Annotated  &&
+                    propertyType.ToString() == property.Type.ToString() ? "= default!;" : "",
             }.Where(i => i.Any()));
         }
 
@@ -93,7 +94,7 @@ namespace SG1.UtilityTypes
                         continue;
                     }
 
-                    var propertyType = transformations.Select(t => t.GetPropertyType(property)).Where(t => !string.IsNullOrWhiteSpace(t)).LastOrDefault() ?? property.Type.ToString();
+                    var propertyType = transformations.Select(t => t.GetPropertyType(property)).Where(t => t != null).LastOrDefault() ?? property.Type;
                     var shouldIncludePropertySetter = transformations.Select(t => t.ShouldIncludePropertySetter(property)).Where(t => t.HasValue).LastOrDefault();
                     indentWriter.WriteLine(
                         PrintProperty(

--- a/src/SG1.UtilityTypes/SG1.UtilityTypes.csproj
+++ b/src/SG1.UtilityTypes/SG1.UtilityTypes.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>SG1.UtilityTypes</PackageId>
     <PackageDescription>Utility Type C# Source Generators, inspired by Typescript</PackageDescription>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>Bart Breen</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/barticus/SG1.UtilityTypes</RepositoryUrl>

--- a/src/SG1.UtilityTypes/Transformations/BaseTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/BaseTransformation.cs
@@ -11,7 +11,7 @@ namespace SG1.UtilityTypes.Transformations
             SourceType = sourceType;
         }
 
-        public virtual string? GetPropertyType(IPropertySymbol property) => null;
+        public virtual ITypeSymbol? GetPropertyType(IPropertySymbol property) => null;
 
         public virtual bool? ShouldIncludeProperty(IPropertySymbol property) => null;
 

--- a/src/SG1.UtilityTypes/Transformations/BaseTransformationReader.cs
+++ b/src/SG1.UtilityTypes/Transformations/BaseTransformationReader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -7,6 +8,8 @@ namespace SG1.UtilityTypes.Transformations
     {
         public abstract string FullyQualifiedMetadataName { get; }
         public abstract string AttributeContent { get; }
+
+        public List<Diagnostic> Diagnostics { get; } = new List<Diagnostic>();
 
         public ITransformation[] ReadTransformations(Compilation compilation, ITypeSymbol candidateTypeSymbol)
         {
@@ -18,12 +21,12 @@ namespace SG1.UtilityTypes.Transformations
                         attributeType, SymbolEqualityComparer.Default
                     )
                 )
-                .Select(ReadTransformationData)
+                .Select(ad => ReadTransformationData(ad, compilation))
                 .Where(t => t != null)
                 .Select(t => t!)
                 .ToArray();
         }
 
-        protected abstract ITransformation? ReadTransformationData(AttributeData attributeData);
+        protected abstract ITransformation? ReadTransformationData(AttributeData attributeData, Compilation compilation);
     }
 }

--- a/src/SG1.UtilityTypes/Transformations/ITransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/ITransformation.cs
@@ -6,7 +6,7 @@ namespace SG1.UtilityTypes.Transformations
     {
         INamedTypeSymbol SourceType { get; }
         bool? ShouldIncludeProperty(IPropertySymbol property);
-        string? GetPropertyType(IPropertySymbol property);
+        ITypeSymbol? GetPropertyType(IPropertySymbol property);
         bool? ShouldIncludePropertySetter(IPropertySymbol property);
     }
 }

--- a/src/SG1.UtilityTypes/Transformations/OmitTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/OmitTransformation.cs
@@ -13,7 +13,7 @@ namespace SG1.UtilityTypes
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
     public sealed class OmitAttribute : Attribute
     {
-        public OmitAttribute(Type sourceType, string[] properties)
+        public OmitAttribute(Type sourceType, params string[] properties)
         {
         }
     }

--- a/src/SG1.UtilityTypes/Transformations/OmitTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/OmitTransformation.cs
@@ -20,7 +20,7 @@ namespace SG1.UtilityTypes
 }
 ";
 
-        protected override ITransformation? ReadTransformationData(AttributeData attributeData)
+        protected override ITransformation? ReadTransformationData(AttributeData attributeData, Compilation compilation)
         {
             var sourceType = attributeData.ConstructorArguments[0].Value as INamedTypeSymbol;
             var properties = attributeData.ConstructorArguments[1].Values.Select(v => v.Value).OfType<string>().ToArray<string>() as string[];

--- a/src/SG1.UtilityTypes/Transformations/PartialTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/PartialTransformation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -14,44 +15,62 @@ namespace SG1.UtilityTypes
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
     public sealed class PartialAttribute : Attribute
     {
-        public PartialAttribute(Type sourceType, string wrappingType = ""Nullable"", bool wrapReferenceTypes = false)
+        public PartialAttribute(Type sourceType, Type? nullableType = null, bool wrapReferenceTypes = false)
         {
         }
     }
 }
 ";
 
-        protected override ITransformation? ReadTransformationData(AttributeData partialAttributeData)
+        protected override ITransformation? ReadTransformationData(AttributeData partialAttributeData, Compilation compilation)
         {
             var sourceType = partialAttributeData.ConstructorArguments[0].Value as INamedTypeSymbol;
-            var wrappingType = partialAttributeData.ConstructorArguments[1].Value as string;
+            INamedTypeSymbol nullableType;
+            if (partialAttributeData.ConstructorArguments[1].IsNull)
+            {
+                nullableType = compilation.GetTypeByMetadataName("System.Nullable`1")!;
+            }
+            else if (partialAttributeData.ConstructorArguments[1].Value is INamedTypeSymbol namedTypeSymbol)
+            {
+                nullableType = namedTypeSymbol.ConstructedFrom;
+            }
+            else
+            {
+                throw new InvalidOperationException("Argument could not be read as an INamedTypeSymbol");
+            }
+            if (!nullableType.IsGenericType || nullableType.TypeArguments.Length != 1)
+            {
+                throw new InvalidOperationException($"{nullableType} needs to be a generic type with 1 argument");
+                //     TODO: report diagnostic here
+            }
+
             var wrapReferenceTypes = partialAttributeData.ConstructorArguments[2].Value as bool?;
-            if (sourceType == null || wrappingType == null || wrapReferenceTypes == null)
+            if (sourceType == null || nullableType == null || wrapReferenceTypes == null)
                 return null;
 
-            return new PartialTransformation(sourceType, wrappingType, wrapReferenceTypes.Value);
+            return new PartialTransformation(sourceType, nullableType, wrapReferenceTypes.Value);
         }
     }
 
     internal sealed class PartialTransformation : BaseTransformation
     {
-        public string WrappingType { get; }
+        public INamedTypeSymbol NullableType { get; }
         public bool WrapReferenceTypes { get; }
 
-        public PartialTransformation(INamedTypeSymbol sourceType, string wrappingType, bool wrapReferenceTypes) : base(sourceType)
+        public PartialTransformation(INamedTypeSymbol sourceType, INamedTypeSymbol nullableType, bool wrapReferenceTypes) : base(sourceType)
         {
-            WrappingType = wrappingType;
+            NullableType = nullableType;
             WrapReferenceTypes = wrapReferenceTypes;
         }
 
-        private bool ShouldWrapType(ITypeSymbol type, string? wrappingType, bool wrapReferenceTypes)
+        private bool ShouldWrapType(ITypeSymbol type, INamedTypeSymbol? nullableType, bool wrapReferenceTypes)
         {
             if (type.IsReferenceType && !wrapReferenceTypes)
             {
                 return false;
             }
 
-            if (string.IsNullOrWhiteSpace(wrappingType))
+            if (nullableType == null)
             {
                 return false;
             }
@@ -61,8 +80,8 @@ namespace SG1.UtilityTypes
 
         public override string? GetPropertyType(IPropertySymbol property)
         {
-            var wrapType = ShouldWrapType(property.Type, WrappingType, WrapReferenceTypes);
-            return wrapType ? $"{WrappingType}<{property.Type}>" : property.Type.WithNullableAnnotation(NullableAnnotation.Annotated).ToString();
+            var wrapType = ShouldWrapType(property.Type, NullableType, WrapReferenceTypes);
+            return wrapType ? NullableType.Construct(property.Type).ToString() : property.Type.WithNullableAnnotation(NullableAnnotation.Annotated).ToString();
         }
     }
 }

--- a/src/SG1.UtilityTypes/Transformations/PickTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/PickTransformation.cs
@@ -14,7 +14,7 @@ namespace SG1.UtilityTypes
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
     public sealed class PickAttribute : Attribute
     {
-        public PickAttribute(Type sourceType, string[] properties)
+        public PickAttribute(Type sourceType, params string[] properties)
         {
         }
     }
@@ -35,6 +35,7 @@ namespace SG1.UtilityTypes
     internal sealed class PickTransformation : BaseTransformation
     {
         private string[] Properties { get; }
+
         public PickTransformation(INamedTypeSymbol sourceType, string[] properties) : base(sourceType)
         {
             Properties = properties;

--- a/src/SG1.UtilityTypes/Transformations/PickTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/PickTransformation.cs
@@ -21,7 +21,7 @@ namespace SG1.UtilityTypes
 }
 ";
 
-        protected override ITransformation? ReadTransformationData(AttributeData attributeData)
+        protected override ITransformation? ReadTransformationData(AttributeData attributeData, Compilation compilation)
         {
             var sourceType = attributeData.ConstructorArguments[0].Value as INamedTypeSymbol;
             var properties = attributeData.ConstructorArguments[1].Values.Select(v => v.Value).OfType<string>().ToArray<string>() as string[];

--- a/src/SG1.UtilityTypes/Transformations/ReadonlyTransformation.cs
+++ b/src/SG1.UtilityTypes/Transformations/ReadonlyTransformation.cs
@@ -21,7 +21,7 @@ namespace SG1.UtilityTypes
 }
 ";
 
-        protected override ITransformation? ReadTransformationData(AttributeData attributeData)
+        protected override ITransformation? ReadTransformationData(AttributeData attributeData, Compilation compilation)
         {
             var sourceType = attributeData.ConstructorArguments[0].Value as INamedTypeSymbol;
             if (sourceType == null)


### PR DESCRIPTION
Resolves:

#3 Constructor args for attributes that take strings should be params string[]
#4 Tests for property types in other namespaces
#5 Make partial attribute use Type instead of string for wrapping type name
#6 Add tests for combined attribute usage